### PR TITLE
Use native service provider for BeeGFS 7.x only.

### DIFF
--- a/manifests/admon.pp
+++ b/manifests/admon.pp
@@ -19,7 +19,6 @@ class beegfs::admon (
   service { 'beegfs-admon':
     ensure    => running,
     enable    => $enable,
-    provider  => redhat,
     require   => Package['beegfs-admon'],
     subscribe => File['/etc/beegfs/beegfs-admon.conf'];
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class beegfs (
   $storage_inodes_emergency_limit = '1M',
   $version = 'present',
   $major_version = '2015',
+  $minor_version = '',
   $interfaces_file = '',
   $net_filter_file = '',
   $helperd_port = '8006',
@@ -34,7 +35,11 @@ class beegfs (
       require yum::repo::beegfs
     }
     '7': {
-      require yum::repo::beegfs7
+      if $minor_version == '1' {
+        require yum::repo::beegfs71
+      else {
+        require yum::repo::beegfs7
+      }
     }
   }
 

--- a/manifests/meta.pp
+++ b/manifests/meta.pp
@@ -10,6 +10,7 @@ class beegfs::meta (
   $interfaces_file      = $beegfs::interfaces_file,
   $net_filter_file      = $beegfs::net_filter_file,
   $meta_template        = $beegfs::meta_template,
+  $major_version        = $beegfs::major_version,
   $allow_first_run_init = true,
   $num_workers          = 0,
 ) inherits beegfs {
@@ -20,11 +21,20 @@ class beegfs::meta (
     require => Package['beegfs-meta'],
     content => template($meta_template),
   }
-  service { 'beegfs-meta':
-    ensure    => running,
-    enable    => $enable,
-    provider  => redhat,
-    require   => Package['beegfs-meta'],
-    subscribe => File['/etc/beegfs/beegfs-meta.conf'];
+  if $major_version == '7' {
+    service { 'beegfs-meta':
+      ensure    => running,
+      enable    => $enable,
+      require   => Package['beegfs-meta'],
+      subscribe =>  File['/etc/beegfs/beegfs-meta.conf'],
+    }
+  } else {
+    service { 'beegfs-meta':
+      ensure    => running,
+      enable    => $enable,
+      provider  => redhat,
+      require   => Package['beegfs-meta'],
+      subscribe => File['/etc/beegfs/beegfs-meta.conf'],
+    }
   }
 }

--- a/manifests/mgmtd.pp
+++ b/manifests/mgmtd.pp
@@ -15,6 +15,7 @@ class beegfs::mgmtd (
   $storage_inodes_low_limit       = $beegfs::storage_inodes_low_limit,
   $storage_inodes_emergency_limit = $beegfs::storage_inodes_emergency_limit,
   $mgmtd_template                 = $beegfs::mgmtd_template,
+  $major_version        = $beegfs::major_version,
   $version                        = $beegfs::version,
   $interfaces_file                = $beegfs::interfaces_file,
   $net_filter_file                = $beegfs::net_filter_file,
@@ -28,11 +29,18 @@ class beegfs::mgmtd (
     require => Package['beegfs-mgmtd'],
     content => template($mgmtd_template),
   }
-  service { 'beegfs-mgmtd':
-    ensure    => running,
-    enable    => $enable,
-    provider  => redhat,
-    require   => Package['beegfs-mgmtd'],
-    subscribe => File['/etc/beegfs/beegfs-mgmtd.conf'];
+  if $major_version == '7' {
+    service { 'beegfs-mgmtd':
+      ensure    => running,
+      enable    => $enable,
+      require   => Package['beegfs-mgmtd'],
+      subscribe => File['/etc/beegfs/beegfs-mgmtd.conf'];
+  } else {
+    service { 'beegfs-mgmtd':
+      ensure    => running,
+      enable    => $enable,
+      provider  => redhat,
+      require   => Package['beegfs-mgmtd'],
+      subscribe => File['/etc/beegfs/beegfs-mgmtd.conf'];
   }
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -10,6 +10,7 @@ class beegfs::storage (
   $interfaces_file      = $beegfs::interfaces_file,
   $net_filter_file      = $beegfs::net_filter_file,
   $storage_template     = $beegfs::storage_template,
+  $major_version        = $beegfs::major_version,
   $allow_first_run_init = true,
   $num_workers          = 16,
 ) inherits beegfs {
@@ -20,11 +21,20 @@ class beegfs::storage (
     require => Package['beegfs-storage'],
     content => template($storage_template),
   }
-  service { 'beegfs-storage':
-    ensure    => running,
-    enable    => $enable,
-    provider  => redhat,
-    require   => Package['beegfs-storage'],
-    subscribe => File['/etc/beegfs/beegfs-storage.conf'],
+  if $major_version == '7' {
+    service { 'beegfs-storage':
+      ensure    => running,
+      enable    => $enable,
+      require   => Package['beegfs-storage'],
+      subscribe => File['/etc/beegfs/beegfs-storage.conf'],
+    }
+  } else {
+    service { 'beegfs-storage':
+      ensure    => running,
+      enable    => $enable,
+      provider  => redhat,
+      require   => Package['beegfs-storage'],
+      subscribe => File['/etc/beegfs/beegfs-storage.conf'],
+    }
   }
 }


### PR DESCRIPTION
Native service provider doesn't work properly on older versions and causes service failures.